### PR TITLE
flush session to ensure DELETE statement is performed before CREATE for LocationSetting

### DIFF
--- a/src/persistence/repository.py
+++ b/src/persistence/repository.py
@@ -250,6 +250,11 @@ class LocationRepository(
             self._session.query(LocationSettings).filter_by(
                 location_id=domain_id
             ).delete()  # todo too dirty?
+            # db operations will be sorted before they are applied
+            # it may happen that the CREATE statement is executed before the DELETE statement
+            # this would fail due to the unique constraint on location_id
+            # flushing the session here will ensure that the DELETE statement is executed before the CREATE statement
+            self._session.flush()
             return DBLocationSettings(
                 active_from=settings.active_from,
                 active_until=settings.active_until,


### PR DESCRIPTION
supposed to solve [this](https://nodeenergy.sentry.io/issues/5925443165/?project=4507814207815680&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=30d&stream_index=5) bug.

Locally I could not reproduce this bug.

The issue might be as follows:
According to [sqlalchemy documentation](https://docs.sqlalchemy.org/en/20/orm/session_api.html#:~:text=Flush%20all%20the,work%20dependency%20solver.) the SQL operations of a session are ordered before they are performed on the database.
> Flush all the object changes to the database.
> 
> Writes out all pending object creations, deletions and modifications to the database as INSERTs, DELETEs, UPDATEs, etc. Operations are automatically ordered by the Session’s unit of work dependency solver.

I am not sure why I could not reproduce the bug locally, but maybe the dependency solver works different on my local machine than on the server. Then on the server the SQL statements where ordered in a way where the creation of the new location settings is performed before the deletion of the old one. This results in the `IntegrityError`.
Since I could not reproduce the bug I cannot be sure whether this fix really solves it. But it should neither break anything so I think it worth testing it on our test system (which unfortunately is the production system)


https://stackoverflow.com/a/60842091/15077097