### PR TITLE
change cron job time to find out if multiple instances are running

### DIFF
--- a/kubernetes/prod-values.yaml
+++ b/kubernetes/prod-values.yaml
@@ -7,7 +7,7 @@ configuration:
   smtp_host: "smtp.office365.com"
   smtp_port: "587"
   smtp_email: "kai.timofejew@node.energy"
-  update_cron: "45 10 * * * "
+  update_cron: "43 10 * * * "
 
 network:
   hostName: "ppapredictions.testsystem.node.energy"

--- a/kubernetes/staging-values.yaml
+++ b/kubernetes/staging-values.yaml
@@ -7,7 +7,7 @@ configuration:
   smtp_host: "smtp.office365.com"
   smtp_port: "587"
   smtp_email: "kai.timofejew@node.energy"
-  update_cron: "45 10 * * * "
+  update_cron: "48 10 * * * "
 
 network:
   hostName: "ppapredictions-staging.testsystem.node.energy"


### PR DESCRIPTION
we observe that multiple prediction files are sent to FPM. To find out if this happens due to multiple instances of the service are running (remote or locally) I changed the cron job times to prod and staging here. This change is supposed to be reversed once the problem is solved.